### PR TITLE
Fixing the name of plugin on directory

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== brave-payments-verification ===
+=== Brave Payments Verification ===
 Contributors: pfefferle, mrose17
 Tags: well-known, well-known-uris, discovery, brave
 Requires at least: 3.5.1


### PR DESCRIPTION
Fixing the name of the plugin to **Brave Payments Verification**.

Currently, the name on [WordPress.org](https://wordpress.org/plugins/brave-payments-verification/) is **brave-payments-verification**, which looks like a slug name.